### PR TITLE
Fix parsing tasks without priority and with emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,16 @@ A minimal dark-mode, browser-based task planner that supports:
 4. Notifications require enabling permissions in the browser.
 
 ## Format Support
-Tasks must follow this format:
+Tasks should include a description followed by `due:` and `time:` fields. A
+priority like `(A)` can be placed at the beginning but is optional.
 
 ```
 (A) Task description @context +project due:YYYY-MM-DD time:HH:MM
 ```
 
-Example:
+Example without priority:
 ```
-(A) Dentist appointment @health +appointments due:2025-06-09 time:13:30
+😴 Nap before shift (1h) @home +rest due:2025-06-15 time:22:00
 ```
 
 ## Notes

--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -57,13 +57,13 @@
   <script>
     function parseTasks(text) {
       return text.trim().split('\n').map(line => {
-        const match = line.match(/\((\w)\)\s+(.*?)\s+due:(\d{4}-\d{2}-\d{2})\s+time:(\d{2}:\d{2})/);
+        const match = line.match(/(?:\((\w)\)\s+)?(.*?)\s+due:(\d{4}-\d{2}-\d{2})\s+time:(\d{2}:\d{2})/);
         if (!match) return null;
         const description = match[2];
         const contextMatch = description.match(/@(\w+)/);
         const context = contextMatch ? contextMatch[1] : '';
         return {
-          priority: match[1],
+          priority: match[1] || '',
           description: description,
           due: match[3],
           time: match[4],
@@ -103,7 +103,8 @@
 
         grouped[date].sort((a, b) => a.time.localeCompare(b.time)).forEach(task => {
           const el = document.createElement('div');
-          el.className = `task priority-${task.priority}`;
+          el.className = 'task';
+          if (task.priority) el.classList.add(`priority-${task.priority}`);
           if (task.context) el.classList.add(`context-${task.context.toLowerCase()}`);
           el.innerHTML = `<span class="time">[${task.time}]</span> ${task.description}`;
           block.appendChild(el);

--- a/todo_goals_requirements.md
+++ b/todo_goals_requirements.md
@@ -19,9 +19,15 @@ Each task must follow this structure **exactly** for it to be parsed and display
 - `due:` — Required. Date in `YYYY-MM-DD` format. Tasks with past due dates are **not shown**.
 - `time:` — Required. Time in `HH:MM` 24-hour format. Used for time sorting and notifications.
 
-### ✅ Valid Example
+### ✅ Valid Examples
+With priority:
 ```
 (A) Take Daisy to the vet @errands +pets due:2025-06-09 time:14:00
+```
+
+Without priority:
+```
+😴 Nap before shift (1h) @home +rest due:2025-06-15 time:22:00
 ```
 
 ### ❌ Invalid Examples


### PR DESCRIPTION
## Summary
- allow optional priority field in `parseTasks`
- adjust task rendering for missing priority
- document that priority is optional with example containing an emoji

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68446347f9808322a628ce079c94b3db