### PR TITLE
Fix local date handling

### DIFF
--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -79,7 +79,7 @@
       warning.textContent = '';
 
       const now = new Date();
-      const today = now.toISOString().split('T')[0];
+      const today = new Date().toLocaleDateString('en-CA');
 
       const futureTasks = tasks.filter(task => task.due >= today);
 
@@ -98,7 +98,9 @@
         const block = document.createElement('div');
         block.className = 'date-block';
         const header = document.createElement('h2');
-        header.textContent = new Date(date).toDateString();
+        const [y, m, d] = date.split('-').map(Number);
+        const localDate = new Date(y, m - 1, d);
+        header.textContent = localDate.toDateString();
         block.appendChild(header);
 
         grouped[date].sort((a, b) => a.time.localeCompare(b.time)).forEach(task => {


### PR DESCRIPTION
## Summary
- ensure today's date uses local time
- correctly convert due dates to local time before displaying

## Testing
- `node --version`
- `TZ="Pacific/Honolulu" node -e "const date='2025-06-10';console.log('UTC parse', new Date(date).toDateString());const [y,m,d]=date.split('-').map(Number);const localDate=new Date(y,m-1,d);console.log('local', localDate.toDateString());"`
- `TZ="Pacific/Honolulu" node -e "console.log(new Date().toLocaleDateString('en-CA'))"`
- `TZ="Pacific/Honolulu" node /tmp/test.js`

------
https://chatgpt.com/codex/tasks/task_e_6844706382a883229710d6251546d302