### PR TITLE
Fix date display timezone issue

### DIFF
--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -104,7 +104,12 @@
         const header = document.createElement('h2');
         const [y, m, d] = date.split('-').map(Number);
         const localDate = new Date(y, m - 1, d);
-        header.textContent = localDate.toDateString();
+        header.textContent = localDate.toLocaleDateString(undefined, {
+          weekday: 'short',
+          month: 'short',
+          day: '2-digit',
+          year: 'numeric'
+        });
         block.appendChild(header);
 
         grouped[date].sort((a, b) => a.time.localeCompare(b.time)).forEach(task => {


### PR DESCRIPTION
## Summary
- render date headers with `toLocaleDateString` so timezone doesn't shift dates

## Testing
- `node -e "console.log(new Date(2025,5,7).toLocaleDateString())"`

------
https://chatgpt.com/codex/tasks/task_e_68447a1472988322b30b78a81cc56d3d