### PR TITLE
Fix timezone for task headers

### DIFF
--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -103,8 +103,8 @@
         block.className = 'date-block';
         const header = document.createElement('h2');
         const [y, m, d] = date.split('-').map(Number);
-        const localDate = new Date(y, m - 1, d);
-        header.textContent = localDate.toLocaleDateString(undefined, {
+        const utcDate = new Date(Date.UTC(y, m - 1, d));
+        header.textContent = utcDate.toLocaleDateString(undefined, {
           weekday: 'short',
           month: 'short',
           day: '2-digit',


### PR DESCRIPTION
## Summary
- use UTC when formatting date headers so tasks display the same day everywhere

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684487b2f63083228950e14e63120f02