### PR TITLE
Fix notification permission check

### DIFF
--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -171,8 +171,9 @@
       reader.readAsText(file);
     });
 
-    // Request notification permission if it hasn't been granted already
-    if (Notification.permission !== "granted") {
+    // Request notification permission only if status is "default"
+    // so browsers don't re-prompt users who previously denied access
+    if (Notification.permission === "default") {
       Notification.requestPermission();
     }
 


### PR DESCRIPTION
## Summary
- modify `to_do_goals.html` to only request notification permission when the status is `"default"`

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684488013cd083228faed04b98263d64