### PR TITLE
Add done button to mark tasks complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A minimal dark-mode, browser-based task planner that supports:
 - Lightweight and offline-capable
 - Automatically saves your last file to local storage
 - Notification reminders for upcoming due times
+- Mark tasks as done with a button
 
 ## Usage
 1. Open `to_do_goals.html` in your browser.

--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -46,6 +46,21 @@
       color: #f44336;
       margin-top: 1em;
     }
+    .done-btn {
+      margin-left: 0.5em;
+      padding: 0.2em 0.4em;
+      background-color: #333;
+      color: #e0e0e0;
+      border: none;
+      cursor: pointer;
+    }
+    .done-btn:hover {
+      background-color: #444;
+    }
+    .task.completed {
+      text-decoration: line-through;
+      opacity: 0.6;
+    }
   </style>
 </head>
 <body>
@@ -74,6 +89,14 @@
       }).filter(Boolean);
     }
 
+    function getCompletedTasks() {
+      return JSON.parse(localStorage.getItem('completedTasks') || '[]');
+    }
+
+    function setCompletedTasks(list) {
+      localStorage.setItem('completedTasks', JSON.stringify(list));
+    }
+
     // Render a list of tasks grouped by date and sorted by time
     // Adds notification timers for upcoming tasks
     function renderTasks(tasks) {
@@ -84,6 +107,8 @@
 
       const now = new Date();
       const today = new Date().toLocaleDateString('en-CA');
+
+      const completed = getCompletedTasks();
 
       const futureTasks = tasks.filter(task => task.due >= today);
 
@@ -117,7 +142,28 @@
           el.className = 'task';
           if (task.priority) el.classList.add(`priority-${task.priority}`);
           if (task.context) el.classList.add(`context-${task.context.toLowerCase()}`);
+          const id = `${task.due}_${task.time}_${task.description}`;
           el.innerHTML = `<span class="time">[${task.time}]</span> ${task.description}`;
+
+          const btn = document.createElement('button');
+          btn.className = 'done-btn';
+          btn.textContent = completed.includes(id) ? 'Undo' : 'Done';
+          if (completed.includes(id)) el.classList.add('completed');
+          btn.addEventListener('click', () => {
+            const list = getCompletedTasks();
+            const index = list.indexOf(id);
+            if (index === -1) {
+              list.push(id);
+              el.classList.add('completed');
+              btn.textContent = 'Undo';
+            } else {
+              list.splice(index, 1);
+              el.classList.remove('completed');
+              btn.textContent = 'Done';
+            }
+            setCompletedTasks(list);
+          });
+          el.appendChild(btn);
           block.appendChild(el);
 
           const dueTime = new Date(`${task.due}T${task.time}:00`);


### PR DESCRIPTION
## Summary
- allow marking tasks as done/undo
- style completed tasks and "Done" button
- store completion state in localStorage
- document the new feature in README

## Testing
- `ls -R | head`

------
https://chatgpt.com/codex/tasks/task_e_68451fca16bc832295a6540b3dc95445