### PR TITLE
Add export feature to To Do Goals

### DIFF
--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -57,6 +57,17 @@
     .done-btn:hover {
       background-color: #444;
     }
+    #exportBtn {
+      margin-left: 0.5em;
+      padding: 0.2em 0.4em;
+      background-color: #333;
+      color: #e0e0e0;
+      border: none;
+      cursor: pointer;
+    }
+    #exportBtn:hover {
+      background-color: #444;
+    }
     .task.completed {
       text-decoration: line-through;
       opacity: 0.6;
@@ -66,6 +77,7 @@
 <body>
   <h1>🗂️ To Do Goals</h1>
   <input type="file" id="fileInput" accept=".txt">
+  <button id="exportBtn">Export to todo.txt</button>
   <div id="taskList"></div>
   <div id="warning" class="warning"></div>
 
@@ -93,14 +105,17 @@
       return JSON.parse(localStorage.getItem('completedTasks') || '[]');
     }
 
-    function setCompletedTasks(list) {
-      localStorage.setItem('completedTasks', JSON.stringify(list));
-    }
+  function setCompletedTasks(list) {
+    localStorage.setItem('completedTasks', JSON.stringify(list));
+  }
+
+  let currentTasks = [];
 
     // Render a list of tasks grouped by date and sorted by time
     // Adds notification timers for upcoming tasks
-    function renderTasks(tasks) {
-      const container = document.getElementById('taskList');
+  function renderTasks(tasks) {
+    currentTasks = tasks;
+    const container = document.getElementById('taskList');
       const warning = document.getElementById('warning');
       container.innerHTML = '';
       warning.textContent = '';
@@ -215,6 +230,23 @@
         warning.textContent = '⚠️ Failed to read file';
       };
       reader.readAsText(file);
+    });
+
+    document.getElementById('exportBtn').addEventListener('click', function() {
+      if (currentTasks.length === 0) return;
+      const completed = getCompletedTasks();
+      const lines = currentTasks.map(task => {
+        const id = `${task.due}_${task.time}_${task.description}`;
+        const prefix = completed.includes(id) ? 'x ' : '';
+        const priority = task.priority ? `(${task.priority}) ` : '';
+        return `${prefix}${priority}${task.description} due:${task.due} time:${task.time}`;
+      });
+      const blob = new Blob([lines.join('\n')], {type: 'text/plain'});
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'todo.txt';
+      a.click();
+      URL.revokeObjectURL(a.href);
     });
 
     // Request notification permission only if status is "default"


### PR DESCRIPTION
## Summary
- add "Export to todo.txt" button
- track current tasks for export
- implement export logic with completion status

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684521cf2b288322b59d5ad8f8d2ff49