### PR TITLE
Add service worker notification scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A minimal dark-mode, browser-based task planner that supports:
 - Task priority coloring via `(A)`, `(B)`, etc.
 - Support for loading from file and storing locally
 - Browser notifications for upcoming tasks
+- Persistent reminders via a service worker when loaded over HTTPS or on `localhost`
 
 ## Features
 - Only shows **today and future** tasks
@@ -22,6 +23,7 @@ A minimal dark-mode, browser-based task planner that supports:
 2. Upload your `todo.txt` file.
 3. Tasks will be grouped by date and displayed in order.
 4. Notifications require enabling permissions in the browser.
+5. For persistent reminders after closing the page, open the planner from a secure origin (`https:` or `http://localhost`).
 
 ## Format Support
 Tasks should include a description followed by `due:` and `time:` fields. A

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,34 @@
+self.addEventListener('install', (e) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(self.clients.claim());
+});
+
+const timers = [];
+
+function schedule(tasks) {
+  const now = Date.now();
+  tasks.forEach(task => {
+    const time = new Date(`${task.due}T${task.time}:00`).getTime();
+    if (time > now) {
+      const timeout = time - now;
+      const id = setTimeout(() => {
+        self.registration.showNotification('Task Reminder', {
+          body: task.description,
+          tag: `${task.due}-${task.time}-${task.description}`
+        });
+      }, timeout);
+      timers.push(id);
+    }
+  });
+}
+
+self.addEventListener('message', (e) => {
+  if (e.data && e.data.type === 'schedule') {
+    timers.forEach(t => clearTimeout(t));
+    timers.length = 0;
+    schedule(e.data.tasks || []);
+  }
+});

--- a/to_do_goals.html
+++ b/to_do_goals.html
@@ -118,6 +118,29 @@
 
   let currentTasks = [];
 
+  let swRegistered = false;
+  if ('serviceWorker' in navigator) {
+    const secure = location.protocol === 'https:' ||
+                   (location.protocol === 'http:' && location.hostname === 'localhost');
+    if (secure) {
+      navigator.serviceWorker.register('service-worker.js').then(() => {
+        return navigator.serviceWorker.ready;
+      }).then(() => {
+        swRegistered = true;
+        if (currentTasks.length) sendTasksToWorker(currentTasks);
+      }).catch(err => {
+        console.warn('Service worker registration failed', err);
+      });
+    }
+  }
+
+  function sendTasksToWorker(tasks) {
+    if (!swRegistered || !navigator.serviceWorker.controller) return;
+    const now = new Date();
+    const future = tasks.filter(t => new Date(`${t.due}T${t.time}:00`) > now);
+    navigator.serviceWorker.controller.postMessage({type: 'schedule', tasks: future});
+  }
+
     // Render a list of tasks grouped by date and sorted by time
     // Adds notification timers for upcoming tasks
   function renderTasks(tasks) {
@@ -189,7 +212,7 @@
           block.appendChild(el);
 
           const dueTime = new Date(`${task.due}T${task.time}:00`);
-          if (dueTime > now && Notification.permission === "granted") {
+          if (!swRegistered && dueTime > now && Notification.permission === "granted") {
             const timeout = dueTime.getTime() - now.getTime();
             setTimeout(() => {
               new Notification(`Task Reminder: ${task.description}`);
@@ -199,6 +222,7 @@
 
         container.appendChild(block);
       });
+      if (swRegistered) sendTasksToWorker(futureTasks);
     }
 
     // Restore the last uploaded task file from localStorage on load

--- a/todo_goals_requirements.md
+++ b/todo_goals_requirements.md
@@ -58,6 +58,8 @@ Task with incorrect date format due:06-09-2025
 ## 🔔 Notifications
 - Triggered for tasks with `due:` date equal to today and future `time:`.
 - Only work if browser notification permissions are granted.
+- When opened over HTTPS or on `localhost`, a service worker schedules future reminders so they appear even after closing the page.
+- If loaded from an insecure origin (e.g. `file://`), reminders only fire while the tab remains open.
 
 ---
 


### PR DESCRIPTION
## Summary
- add service-worker.js for background notification scheduling
- register service worker when served on https or localhost
- send tasks to service worker so notifications fire even when page is closed
- fallback to page-level timers if registration fails
- document secure-origin requirements for persistent notifications

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c3900bfe88322abbcc176c8c15cb3